### PR TITLE
Ignore hidden dirs

### DIFF
--- a/examples/cli_hidden_file_test_fixture/.hidden_dir/tests/some_ignored_file_test.py
+++ b/examples/cli_hidden_file_test_fixture/.hidden_dir/tests/some_ignored_file_test.py
@@ -1,0 +1,29 @@
+from pyne.pyne_test_collector import describe, fdescribe, fit, it
+from pyne.pyne_tester import pyne
+
+
+@pyne
+def some_focusing_test():
+    @fit("can be focused")
+    def _(self):
+        pass
+
+    @fit("can be focused")
+    def _(self):
+        pass
+
+    @it("can be ignored")
+    def _(self):
+        pass
+
+    @fdescribe("a focused block")
+    def _():
+        @it("runs its children")
+        def _(self):
+            pass
+
+        @describe("its grandchildren")
+        def _():
+            @it("also run")
+            def _(self):
+                pass

--- a/pyne/cli.py
+++ b/pyne/cli.py
@@ -34,10 +34,11 @@ class PyneCliHelper:
     @staticmethod
     def load_tests_in_subdirectories(path):
         for content in os.listdir(path):
-            content_path = os.path.join(path, content)
-            if os.path.isdir(content_path):
-                cli_helper.load_tests_in_dir(content_path)
-                cli_helper.load_tests_in_subdirectories(content_path)
+            if content[:1] != '.':
+                content_path = os.path.join(path, content)
+                if os.path.isdir(content_path):
+                    cli_helper.load_tests_in_dir(content_path)
+                    cli_helper.load_tests_in_subdirectories(content_path)
 
     def setup_reporting(self):
         self.report_between_suites = config.report_between_suites

--- a/tests/cli_test.py
+++ b/tests/cli_test.py
@@ -7,7 +7,7 @@ from pyne import cli
 from pyne.expectations import expect
 from pyne.pyne_config import config
 from tests.test_helpers.test_resource_paths import cli_test_fixture_path, pyne_path, cli_two_file_test_fixture_path, \
-    cli_focused_test_fixture_path, cli_nested_directory_tests_fixture_path
+    cli_focused_test_fixture_path, cli_nested_directory_tests_fixture_path, cli_hidden_file_path
 
 
 def copy_to_working_directory(resource_path):
@@ -64,6 +64,14 @@ def test__when_there_are_nested_directories_of_test_files__summarizes_the_result
         expect(result.output).to_contain("some_nested_directory_test")
         expect(result.output).to_contain("1 failed, 3 passed")
 
+def test_when_there_is_a_hidden_subdirectory__does_not_look_for_tests():
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        copy_to_working_directory(path.join(cli_hidden_file_path, '.hidden_dir'))
+        copy_to_working_directory(pyne_path)
+
+        result = runner.invoke(cli.main)
+        expect(result.output).to_contain("Ran 0 tests")
 
 def test_cleanup():
     config.report_between_suites = True

--- a/tests/test_helpers/test_resource_paths.py
+++ b/tests/test_helpers/test_resource_paths.py
@@ -8,4 +8,5 @@ cli_test_fixture_path = path.join(project_root, "examples", "cli_single_test_fix
 cli_two_file_test_fixture_path = path.join(project_root, "examples", "cli_two_file_test_fixture")
 cli_nested_directory_tests_fixture_path = path.join(project_root, "examples", "nested_directory_tests_fixture")
 cli_focused_test_fixture_path = path.join(project_root, "examples", "cli_focused_test_fixture")
+cli_hidden_file_path = path.join(project_root, "examples", "cli_hidden_file_test_fixture")
 pyne_path = path.join(project_root, "pyne")


### PR DESCRIPTION
As a side effect of the new pyne recursive CLI test finder, when there is a hidden directory (perhaps a .venv directory containing pyne, itself), in the same directory as the code being tested, the CLI attempts to run tests in that directory. This PR checks for a '.' before recursively looking in that subdir.