### PR TITLE
to_raise_error_with_message: Compare to actual exception message

### DIFF
--- a/pynetest/lib/expectations/raise_message_expectation.py
+++ b/pynetest/lib/expectations/raise_message_expectation.py
@@ -8,6 +8,6 @@ class RaiseMessageExpectation(RaiseExpectation):
         expected_message = params[0]
         message_matcher = Matcher("with_message",
                                   lambda exception, message:
-                                  equal_to(message).matches(exception.args[0]),
+                                  equal_to(message).matches(str(exception)),
                                   expected_message)
-        super().__init__(message_matcher, exception_format=lambda e: e.args[0])
+        super().__init__(message_matcher, exception_format=lambda e: str(e))

--- a/tests/expectations_test.py
+++ b/tests/expectations_test.py
@@ -1,3 +1,5 @@
+import subprocess
+
 from pynetest.expectations import expect
 from pynetest.matchers import anything, equal_to, match
 from tests.test_helpers.expectation_helpers import expect_expectation_to_fail_with_message
@@ -57,6 +59,13 @@ def test__to_raise_error_with_message__can_pass():
     expect(error_method).to_raise_error_with_message("some message")
 
 
+def test__to_raise_error_with_message__when_message_is_not_first_argument__can_pass():
+    def error_method():
+        raise subprocess.CalledProcessError(1, ['some-command', 'some-argument'])
+
+    expect(error_method).to_raise_error_with_message("Command '['some-command', 'some-argument']' returned non-zero exit status 1.")
+
+
 def test__to_raise_error_with_message__can_fail_because_the_message_is_wrong():
     def error_method():
         raise Exception("some message")
@@ -64,6 +73,15 @@ def test__to_raise_error_with_message__can_fail_because_the_message_is_wrong():
     expect_expectation_to_fail_with_message(
         lambda: expect(error_method).to_raise_error_with_message("some other message"),
         "to raise an exception with message.* but the exception was")
+
+
+def test__to_raise_error_with_message__when_message_is_not_first_argument__can_fail_because_the_message_is_wrong():
+    def error_method():
+        raise subprocess.CalledProcessError(1, ['some-command', 'some-argument'])
+
+    expect_expectation_to_fail_with_message(
+        lambda: expect(error_method).to_raise_error_with_message("some other message"),
+        "to raise an exception with message <'some other message'> but the exception was <Command '\['some-command', 'some-argument'\]' returned non-zero exit status 1.>")
 
 
 def test__to_raise_error_with_message__can_fail_because_no_error_is_raised():


### PR DESCRIPTION
Example code:

```
def f():
    raise e
expect(f).to_raise_error_with_message(msg)
```

Previous behavior: Asserts that `e.args[0] == msg`

New behavior: Asserts that `str(e) == msg`

In some cases this behavior is equivalent, but not all.

Resolves: https://github.com/Avvir/pyne/issues/8