### PR TITLE
Add a __main__.py to allow running pyne as a module

### DIFF
--- a/pynetest/__main__.py
+++ b/pynetest/__main__.py
@@ -1,0 +1,4 @@
+from .cli import main
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Instead of:

```
pipenv run python path/to/pynetest/cli.py tests_directory
```

You can now run:

```
pipenv run python -m pynetest tests_directory
```