### PR TITLE
Add failures list

### DIFF
--- a/pynetest/lib/result_reporters/pyne_result_reporters.py
+++ b/pynetest/lib/result_reporters/pyne_result_reporters.py
@@ -249,6 +249,21 @@ class PyneFailureSummaryReporter(StatTrackingReporter):
         return self._printable(result)
 
 
+class PyneFailuresListReporter(StatTrackingReporter):
+    def __init__(self):
+        super().__init__()
+        self.failures_list = []
+
+    def report_failure(self, failed_behavior, it_block, filtered_exception, timing_millis):
+        self.failures_list.append((failed_behavior, it_block))
+
+    def report_end_result(self):
+        result = ""
+        for behavior, it_block in self.failures_list:
+            result += colored(f"{it_block.parent.description}: {it_block.description}", 'red') + "\n"
+        return self._printable(result)
+
+
 class CompositeReporter:
     def __init__(self, *reporters):
         self.reporters = reporters
@@ -286,11 +301,13 @@ def reporter_factory():
     during_execution_reporters = (
         PrintingReporter(PyneTreeReporter()),
         PrintingReporter(PyneStatSummaryReporter()),
+        PrintingReporter(PyneFailuresListReporter()),
         PrintingReporter(PyneFailureSummaryReporter())
     )
     summary_reporters = (
         PrintingReporter(RecordForSummaryReporter(PyneTreeReporter())),
         PrintingReporter(RecordForSummaryReporter(PyneStatSummaryReporter())),
+        PrintingReporter(RecordForSummaryReporter(PyneFailuresListReporter())),
         PrintingReporter(RecordForSummaryReporter(PyneXmlReporter())),
     )
 

--- a/pynetest/lib/result_reporters/pyne_result_reporters.py
+++ b/pynetest/lib/result_reporters/pyne_result_reporters.py
@@ -260,8 +260,14 @@ class PyneFailuresListReporter(StatTrackingReporter):
     def report_end_result(self):
         result = ""
         for behavior, it_block in self.failures_list:
-            result += colored(f"{it_block.parent.description}: {it_block.description}", 'red') + "\n"
+            result += colored(self.compose_message(it_block), 'red') + "\n"
         return self._printable(result)
+
+    def compose_message(self, it_block):
+        if it_block.parent:
+            return self.compose_message(it_block.parent) + f" >> {it_block.description}"
+        else:
+            return f"{it_block.description}"
 
 
 class CompositeReporter:

--- a/tests/cli_test.py
+++ b/tests/cli_test.py
@@ -64,6 +64,8 @@ def test__when_there_are_nested_directories_of_test_files__summarizes_the_result
         expect(result.output).to_contain("some_top_directory_test")
         expect(result.output).to_contain("some_nested_directory_test")
         expect(result.output).to_contain("1 failed, 3 passed")
+        expect(result.output).to_contain("When setup fails: can fail")
+
 
 def test_when_there_is_a_hidden_subdirectory__does_not_look_for_tests():
     runner = CliRunner()
@@ -73,6 +75,7 @@ def test_when_there_is_a_hidden_subdirectory__does_not_look_for_tests():
 
         result = runner.invoke(cli.main)
         expect(result.output).to_contain("Ran 0 tests")
+
 
 def test_when_there_is_a_list_of_excluded_tests__does_not_run_them():
     runner = CliRunner()
@@ -88,6 +91,7 @@ def test_when_there_is_a_list_of_excluded_tests__does_not_run_them():
         # import time
         # time.sleep(50000)
 
+
 def test_when_there_is_a_failing_test__does_exits_with_code_1():
     runner = CliRunner()
     with runner.isolated_filesystem():
@@ -96,6 +100,7 @@ def test_when_there_is_a_failing_test__does_exits_with_code_1():
         result = runner.invoke(cli.main)
         expect(result.exit_code).to_be(1)
         expect(result.exception).to_be_a(SystemExit)
+
 
 def test_cleanup():
     config.report_between_suites = True

--- a/tests/cli_test.py
+++ b/tests/cli_test.py
@@ -64,7 +64,7 @@ def test__when_there_are_nested_directories_of_test_files__summarizes_the_result
         expect(result.output).to_contain("some_top_directory_test")
         expect(result.output).to_contain("some_nested_directory_test")
         expect(result.output).to_contain("1 failed, 3 passed")
-        expect(result.output).to_contain("When setup fails: can fail")
+        expect(result.output).to_contain("All Tests >> some_nested_directory_test >> When setup fails >> can fail")
 
 
 def test_when_there_is_a_hidden_subdirectory__does_not_look_for_tests():

--- a/tests/lib/result_reporters/pyne_failures_list_reporter_test.py
+++ b/tests/lib/result_reporters/pyne_failures_list_reporter_test.py
@@ -13,9 +13,10 @@ def test__report_brief_description_for_all_failures():
         try:
             raise exception
         except Exception as e:
-            describe_block = DescribeBlock(None, "When description", None)
+            top_describe_block = DescribeBlock(None, "When Top describe", None)
+            describe_block = DescribeBlock(top_describe_block, "When description", None)
             block = ItBlock(describe_block, "It does", None)
             reporter.report_failure(block, block, e, 0)
         reporter.report_end_result()
 
-    expect(printed_text).to_contain(contains("When description: It does"))
+    expect(printed_text).to_contain(contains("When Top describe >> When description >> It does"))

--- a/tests/lib/result_reporters/pyne_failures_list_reporter_test.py
+++ b/tests/lib/result_reporters/pyne_failures_list_reporter_test.py
@@ -1,0 +1,21 @@
+from pynetest.expectations import expect
+from pynetest.lib.pyne_test_blocks import ItBlock, DescribeBlock
+from pynetest.lib.result_reporters.printing_reporter import PrintingReporter
+from pynetest.lib.result_reporters.pyne_result_reporters import PyneFailuresListReporter
+from pynetest.matchers import contains
+from tests.test_helpers.fake_print import StubPrint, printed_text
+
+
+def test__report_brief_description_for_all_failures():
+    reporter = PrintingReporter(PyneFailuresListReporter())
+    with StubPrint():
+        exception = Exception()
+        try:
+            raise exception
+        except Exception as e:
+            describe_block = DescribeBlock(None, "When description", None)
+            block = ItBlock(describe_block, "It does", None)
+            reporter.report_failure(block, block, e, 0)
+        reporter.report_end_result()
+
+    expect(printed_text).to_contain(contains("When description: It does"))


### PR DESCRIPTION
Report a list of test failures _after_ the test summary. Failures are reported in the following format:

All tests >> test_suite_name >> top level describe >> ... >> it block text